### PR TITLE
fix: parcel can't resolve path aliases

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,7 @@
+{
+  "extends": "@parcel/config-default",
+  "resolvers": [
+    "parcel-resolver-ts-base-url",
+    "..."
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
         "parcel": "^2.9.3",
+        "parcel-resolver-ts-base-url": "^1.3.1",
         "typescript": "^5.1.6",
         "vite-tsconfig-paths": "^4.2.0",
         "vitest": "^0.33.0"
@@ -6568,6 +6569,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/parcel-resolver-ts-base-url": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/parcel-resolver-ts-base-url/-/parcel-resolver-ts-base-url-1.3.1.tgz",
+      "integrity": "sha512-/GfSk1P6oW7uXtViKlqGtH406kQ17Cu+bKHVTdbuIh8t8hICsJrYRqeDDx1dJWsiMAKvtXzXT0TBWLkdusS8PQ==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "parcel": "^2"
+      },
+      "peerDependencies": {
+        "@parcel/plugin": "^2.0.0",
+        "parcel": "^2.0.0"
       }
     },
     "node_modules/parent-module": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "parcel": "^2.9.3",
+    "parcel-resolver-ts-base-url": "^1.3.1",
     "typescript": "^5.1.6",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.33.0"


### PR DESCRIPTION
`parcel-resolver-ts-base-url` package installed and added into the `.parcelrc` config to parcel to be able to resolve `TypeScript path aliases`.