### PR TITLE
getResult function improvements

### DIFF
--- a/src/functions/getResult/index.ts
+++ b/src/functions/getResult/index.ts
@@ -1,13 +1,29 @@
 /* eslint-disable no-eval */
 import { isEndsWithOperator, removeCharactersFromEnd } from '@src/utils';
 import { CalculationResult, CalculationString } from '@src/types';
+import { validateCalculationString } from './validateCalculationString';
 
-const getResult = (calculationString: CalculationString): CalculationResult => {
-  if (isEndsWithOperator(calculationString)) {
-    return eval(removeCharactersFromEnd(calculationString));
+const defaultOptions = {
+  validation: true,
+};
+
+const getResult = (
+  calculationString: CalculationString,
+  options = defaultOptions,
+): CalculationResult => {
+  try {
+    if (options.validation && !validateCalculationString(calculationString)) {
+      throw new Error();
+    }
+
+    if (isEndsWithOperator(calculationString)) {
+      return eval(removeCharactersFromEnd(calculationString));
+    }
+
+    return eval(calculationString);
+  } catch {
+    throw new Error('Calculation string is in an unsupported format');
   }
-
-  return eval(calculationString);
 };
 
 export { getResult };

--- a/src/functions/getResult/test.ts
+++ b/src/functions/getResult/test.ts
@@ -1,6 +1,26 @@
 import { getResult } from '.';
 
 describe('getResult (Function)', () => {
+  const errorString = 'unsupported format';
+
+  test('It should use the default validation option true if the validation option is not provided', () => {
+    expect(() => getResult('someDangerousFunction()')).toThrowError(
+      errorString,
+    );
+  });
+  test('It should validate the calculation string if the validation option is true', () => {
+    expect(() =>
+      getResult('console.log("Hello World")', { validation: true }),
+    ).toThrow(errorString);
+  });
+  test('It should not validate the calculation string if the validation option is false', () => {
+    const result = getResult('"Hello World"', { validation: false });
+
+    expect(result).toBe('Hello World');
+  });
+  test('It should throw error if the calculation string is validated but unsupported for eval function', () => {
+    expect(() => getResult('24++')).toThrowError(errorString);
+  });
   test('If there is an operator end of the calculation string, it should removes it and returns the result', () => {
     const result = getResult('10+4-3*3+');
 

--- a/src/functions/getResult/test.ts
+++ b/src/functions/getResult/test.ts
@@ -11,7 +11,7 @@ describe('getResult (Function)', () => {
   test('It should validate the calculation string if the validation option is true', () => {
     expect(() =>
       getResult('console.log("Hello World")', { validation: true }),
-    ).toThrow(errorString);
+    ).toThrowError(errorString);
   });
   test('It should not validate the calculation string if the validation option is false', () => {
     const result = getResult('"Hello World"', { validation: false });

--- a/src/functions/getResult/validateCalculationString.ts
+++ b/src/functions/getResult/validateCalculationString.ts
@@ -1,0 +1,11 @@
+import { CalculationString } from '@src/types';
+
+const validateCalculationString = (
+  calculationString: CalculationString,
+): boolean => {
+  const validationRegex = /^[0-9.+\-*/]+$/;
+
+  return validationRegex.test(calculationString);
+};
+
+export { validateCalculationString };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "lib": ["ESNext", "DOM"],
     "types": ["vitest/globals"],
+    "strict": true,
     "paths": {
       "@src/*": ["./src/*"]
     }


### PR DESCRIPTION
The `getResult` function has been updated to include an `options` parameter.

The parameter accepts an object containing `validation` property, which can be of `boolean` type. If `options` parameter is not provided, it defaults to `true`.