### PR TITLE
TypeScript type checking improvements

### DIFF
--- a/src/utils/isEndsWithOperator/index.ts
+++ b/src/utils/isEndsWithOperator/index.ts
@@ -1,7 +1,10 @@
 import { operators } from '@src/constants';
 import { CalculationString } from '@src/types';
 
-const isEndsWithOperator = (calculationString: CalculationString) =>
-  operators.includes(calculationString.at(-1));
+const isEndsWithOperator = (calculationString: CalculationString) => {
+  const lastCharacter = calculationString.at(-1);
+
+  return lastCharacter ? operators.includes(lastCharacter) : false;
+};
 
 export { isEndsWithOperator };

--- a/src/utils/isEndsWithOperator/test.ts
+++ b/src/utils/isEndsWithOperator/test.ts
@@ -1,6 +1,11 @@
 import { isEndsWithOperator } from '.';
 
 describe('isEndsWithOperator (Utility Function)', () => {
+  test('It should return false if the calculation string is empty', () => {
+    const check = isEndsWithOperator('');
+
+    expect(check).toBe(false);
+  });
   test('It should return true if there is an operator in the end of the calculation string', () => {
     const check = isEndsWithOperator('3+5-');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ESNext", "DOM"],
     "types": ["vitest/globals"],
     "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "paths": {
       "@src/*": ["./src/*"]
     }


### PR DESCRIPTION
Added `strict`, `skipLibCheck`, and `forceConsistentCasingInFileNames` properties to `tsconfig.json` for better type checking.

Update `isEndsWithOperator` utility function and its tests to align with `strict` property.