### PR TITLE
Variable naming refactor

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,0 @@
-export * from './operators';

--- a/src/constants/operators.ts
+++ b/src/constants/operators.ts
@@ -1,3 +1,0 @@
-const operators = ['+', '-', '*', '/'];
-
-export { operators };

--- a/src/functions/addDecimal/index.ts
+++ b/src/functions/addDecimal/index.ts
@@ -2,19 +2,16 @@ import { Calculation } from '@src/types';
 import { isEndsWith, isEndsWithOperator } from '@src/utils';
 import { isEndsWithDecimal } from './utils';
 
-const addDecimal = (calculationString: Calculation): Calculation => {
-  if (
-    isEndsWith(calculationString, '.') ||
-    isEndsWithDecimal(calculationString)
-  ) {
-    return calculationString;
+const addDecimal = (calculation: Calculation): Calculation => {
+  if (isEndsWith(calculation, '.') || isEndsWithDecimal(calculation)) {
+    return calculation;
   }
 
-  if (calculationString.length === 0 || isEndsWithOperator(calculationString)) {
-    return `${calculationString}0.`;
+  if (calculation.length === 0 || isEndsWithOperator(calculation)) {
+    return `${calculation}0.`;
   }
 
-  return `${calculationString}.`;
+  return `${calculation}.`;
 };
 
 export { addDecimal };

--- a/src/functions/addDecimal/index.ts
+++ b/src/functions/addDecimal/index.ts
@@ -1,10 +1,8 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { isEndsWith, isEndsWithOperator } from '@src/utils';
 import { isEndsWithDecimal } from './utils';
 
-const addDecimal = (
-  calculationString: CalculationString,
-): CalculationString => {
+const addDecimal = (calculationString: Calculation): Calculation => {
   if (
     isEndsWith(calculationString, '.') ||
     isEndsWithDecimal(calculationString)

--- a/src/functions/addDecimal/test.ts
+++ b/src/functions/addDecimal/test.ts
@@ -2,40 +2,40 @@ import { addDecimal } from '.';
 
 describe('addDecimal (Function)', () => {
   test('It should do nothing if the last character is a point', () => {
-    const calculationString = '24+7.';
-    const newCalculationString = addDecimal(calculationString);
+    const calculation = '24+7.';
+    const newCalculation = addDecimal(calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should do nothing if the last two characters are a zero and point', () => {
-    const calculationString1 = '83/0.';
-    const calculationString2 = '200.';
-    const newCalculationString1 = addDecimal(calculationString1);
-    const newCalculationString2 = addDecimal(calculationString2);
+    const calculation1 = '83/0.';
+    const calculation2 = '200.';
+    const newCalculation1 = addDecimal(calculation1);
+    const newCalculation2 = addDecimal(calculation2);
 
-    expect(newCalculationString1).toBe(calculationString1);
-    expect(newCalculationString2).toBe(calculationString2);
+    expect(newCalculation1).toBe(calculation1);
+    expect(newCalculation2).toBe(calculation2);
   });
   test('It should not add a point if the last number is a decimal number', () => {
-    const calculationString = '76-3.83';
+    const calculation = '76-3.83';
 
-    const newCalculationString = addDecimal(calculationString);
+    const newCalculation = addDecimal(calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should add a zero and point at the beginning if the calculation string is empty', () => {
-    const newCalculationString = addDecimal('');
+    const newCalculation = addDecimal('');
 
-    expect(newCalculationString).toBe('0.');
+    expect(newCalculation).toBe('0.');
   });
   test('It should add a zero and point if the last character is an operator', () => {
-    const newCalculationString = addDecimal('23-');
+    const newCalculation = addDecimal('23-');
 
-    expect(newCalculationString).toBe('23-0.');
+    expect(newCalculation).toBe('23-0.');
   });
   test('It should add point if the last character is a whole number', () => {
-    const newCalculationString = addDecimal('71-2');
+    const newCalculation = addDecimal('71-2');
 
-    expect(newCalculationString).toBe('71-2.');
+    expect(newCalculation).toBe('71-2.');
   });
 });

--- a/src/functions/addDecimal/utils.ts
+++ b/src/functions/addDecimal/utils.ts
@@ -1,9 +1,9 @@
 import { Calculation } from '@src/types';
 
-const isEndsWithDecimal = (calculationString: Calculation) => {
+const isEndsWithDecimal = (calculation: Calculation) => {
   const decimalRegex = /^.*(\D{1})?\d+\.\d+$/;
 
-  return decimalRegex.test(calculationString);
+  return decimalRegex.test(calculation);
 };
 
 export { isEndsWithDecimal };

--- a/src/functions/addDecimal/utils.ts
+++ b/src/functions/addDecimal/utils.ts
@@ -1,6 +1,6 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
-const isEndsWithDecimal = (calculationString: CalculationString) => {
+const isEndsWithDecimal = (calculationString: Calculation) => {
   const decimalRegex = /^.*(\D{1})?\d+\.\d+$/;
 
   return decimalRegex.test(calculationString);

--- a/src/functions/addNumber/index.ts
+++ b/src/functions/addNumber/index.ts
@@ -1,11 +1,11 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { removeCharactersFromEnd } from '@src/utils';
 import { isEndsWithLeadingZero, isTextSingleNumber } from './utils';
 
 const addNumber = (
   numberToAdd: string,
-  calculationString: CalculationString,
-): CalculationString => {
+  calculationString: Calculation,
+): Calculation => {
   if (!isTextSingleNumber(numberToAdd)) {
     throw new Error(
       "The 'numberToAdd' parameter should be a single-character string that holds a valid numeric value",

--- a/src/functions/addNumber/index.ts
+++ b/src/functions/addNumber/index.ts
@@ -4,7 +4,7 @@ import { isEndsWithLeadingZero, isTextSingleNumber } from './utils';
 
 const addNumber = (
   numberToAdd: string,
-  calculationString: Calculation,
+  calculation: Calculation,
 ): Calculation => {
   if (!isTextSingleNumber(numberToAdd)) {
     throw new Error(
@@ -12,15 +12,15 @@ const addNumber = (
     );
   }
 
-  if (isEndsWithLeadingZero(calculationString)) {
+  if (isEndsWithLeadingZero(calculation)) {
     if (numberToAdd === '0') {
-      return calculationString;
+      return calculation;
     }
 
-    return `${removeCharactersFromEnd(calculationString)}${numberToAdd}`;
+    return `${removeCharactersFromEnd(calculation)}${numberToAdd}`;
   }
 
-  return `${calculationString}${numberToAdd}`;
+  return `${calculation}${numberToAdd}`;
 };
 
 export { addNumber };

--- a/src/functions/addNumber/test.ts
+++ b/src/functions/addNumber/test.ts
@@ -5,40 +5,40 @@ describe('addNumber (Function)', () => {
     expect(() => addNumber('2432', '24+97')).toThrowError('single-character');
   });
   test('It should not add the given number if the calculation string only contains a single zero and the given number is zero', () => {
-    const calculationString = '0';
-    const newCalculationString = addNumber('0', calculationString);
+    const calculation = '0';
+    const newCalculation = addNumber('0', calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should replace the zero with the given number if the calculation string only contains a single zero', () => {
-    const newCalculationString = addNumber('5', '0');
+    const newCalculation = addNumber('5', '0');
 
-    expect(newCalculationString).toBe('5');
+    expect(newCalculation).toBe('5');
   });
   test('It should not add the given number if the calculation string ends with single zero and the given number is zero', () => {
-    const calculationString = '7*0';
-    const newCalculationString = addNumber('0', calculationString);
+    const calculation = '7*0';
+    const newCalculation = addNumber('0', calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should replace the zero with the given number if the calculation string ends with a single zero', () => {
-    const newCalculationString = addNumber('2', '234+0');
+    const newCalculation = addNumber('2', '234+0');
 
-    expect(newCalculationString).toBe('234+2');
+    expect(newCalculation).toBe('234+2');
   });
   test('It should add the given number to the empty calculation string', () => {
-    const newCalculationString = addNumber('9', '');
+    const newCalculation = addNumber('9', '');
 
-    expect(newCalculationString).toBe('9');
+    expect(newCalculation).toBe('9');
   });
   test('It should add zero if the given number is zero and the last number is a decimal number', () => {
-    const newCalculationString = addNumber('0', '1+2.00');
+    const newCalculation = addNumber('0', '1+2.00');
 
-    expect(newCalculationString).toBe('1+2.000');
+    expect(newCalculation).toBe('1+2.000');
   });
   test('It should add the given number to the end of the calculation string', () => {
-    const newCalculationString = addNumber('5', '2+3');
+    const newCalculation = addNumber('5', '2+3');
 
-    expect(newCalculationString).toBe('2+35');
+    expect(newCalculation).toBe('2+35');
   });
 });

--- a/src/functions/addNumber/utils.ts
+++ b/src/functions/addNumber/utils.ts
@@ -1,9 +1,9 @@
 import { Calculation } from '@src/types';
 
-const isEndsWithLeadingZero = (calculationString: Calculation): boolean => {
+const isEndsWithLeadingZero = (calculation: Calculation): boolean => {
   const leadingZeroRegex = /^(.*[^.\d])?0$/;
 
-  return leadingZeroRegex.test(calculationString);
+  return leadingZeroRegex.test(calculation);
 };
 
 const isTextSingleNumber = (text: string): boolean => {

--- a/src/functions/addNumber/utils.ts
+++ b/src/functions/addNumber/utils.ts
@@ -1,8 +1,6 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
-const isEndsWithLeadingZero = (
-  calculationString: CalculationString,
-): boolean => {
+const isEndsWithLeadingZero = (calculationString: Calculation): boolean => {
   const leadingZeroRegex = /^(.*[^.\d])?0$/;
 
   return leadingZeroRegex.test(calculationString);

--- a/src/functions/addOperator/index.ts
+++ b/src/functions/addOperator/index.ts
@@ -3,13 +3,13 @@ import {
   isEndsWithOperator,
   removeCharactersFromEnd,
 } from '@src/utils';
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { toggleMinusOperator } from './utils';
 
 const addOperator = (
   operator: '+' | '-' | '*' | '/',
-  calculationString: CalculationString,
-): CalculationString => {
+  calculationString: Calculation,
+): Calculation => {
   if (operator === '-') {
     return toggleMinusOperator(calculationString);
   }

--- a/src/functions/addOperator/index.ts
+++ b/src/functions/addOperator/index.ts
@@ -7,30 +7,30 @@ import { Calculation } from '@src/types';
 import { toggleMinusOperator } from './utils';
 
 const addOperator = (
-  operator: '+' | '-' | '*' | '/',
+  operatorToAdd: '+' | '-' | '*' | '/',
   calculation: Calculation,
 ): Calculation => {
-  if (operator === '-') {
+  if (operatorToAdd === '-') {
     return toggleMinusOperator(calculation);
   }
 
   if (isEndsWithOperator(calculation)) {
     if (isEndsWith(calculation, '-')) {
-      return `${removeCharactersFromEnd(calculation, 2)}${operator}`;
+      return `${removeCharactersFromEnd(calculation, 2)}${operatorToAdd}`;
     }
 
-    if (isEndsWith(calculation, operator)) {
+    if (isEndsWith(calculation, operatorToAdd)) {
       return calculation;
     }
 
-    return `${removeCharactersFromEnd(calculation)}${operator}`;
+    return `${removeCharactersFromEnd(calculation)}${operatorToAdd}`;
   }
 
   if (calculation.length === 0) {
     return calculation;
   }
 
-  return `${calculation}${operator}`;
+  return `${calculation}${operatorToAdd}`;
 };
 
 export { addOperator };

--- a/src/functions/addOperator/index.ts
+++ b/src/functions/addOperator/index.ts
@@ -8,29 +8,29 @@ import { toggleMinusOperator } from './utils';
 
 const addOperator = (
   operator: '+' | '-' | '*' | '/',
-  calculationString: Calculation,
+  calculation: Calculation,
 ): Calculation => {
   if (operator === '-') {
-    return toggleMinusOperator(calculationString);
+    return toggleMinusOperator(calculation);
   }
 
-  if (isEndsWithOperator(calculationString)) {
-    if (isEndsWith(calculationString, '-')) {
-      return `${removeCharactersFromEnd(calculationString, 2)}${operator}`;
+  if (isEndsWithOperator(calculation)) {
+    if (isEndsWith(calculation, '-')) {
+      return `${removeCharactersFromEnd(calculation, 2)}${operator}`;
     }
 
-    if (isEndsWith(calculationString, operator)) {
-      return calculationString;
+    if (isEndsWith(calculation, operator)) {
+      return calculation;
     }
 
-    return `${removeCharactersFromEnd(calculationString)}${operator}`;
+    return `${removeCharactersFromEnd(calculation)}${operator}`;
   }
 
-  if (calculationString.length === 0) {
-    return calculationString;
+  if (calculation.length === 0) {
+    return calculation;
   }
 
-  return `${calculationString}${operator}`;
+  return `${calculation}${operator}`;
 };
 
 export { addOperator };

--- a/src/functions/addOperator/test.ts
+++ b/src/functions/addOperator/test.ts
@@ -3,65 +3,65 @@ import { addOperator } from '.';
 describe('addOperator (Function)', () => {
   describe('Empty calculation string', () => {
     test('It should add a minus operator if the given operator is a minus operator', () => {
-      const newCalculationString = addOperator('-', '');
+      const newCalculation = addOperator('-', '');
 
-      expect(newCalculationString).toBe('-');
+      expect(newCalculation).toBe('-');
     });
     test('It should do nothing if the given operator is other than a minus operator', () => {
-      const newCalculationString = addOperator('*', '');
+      const newCalculation = addOperator('*', '');
 
-      expect(newCalculationString).toBe('');
+      expect(newCalculation).toBe('');
     });
   });
 
   describe('Single character calculation string', () => {
     test('It should remove the minus operator if both the first character and the given operator are minus operators', () => {
-      const newCalculationString = addOperator('-', '-');
+      const newCalculation = addOperator('-', '-');
 
-      expect(newCalculationString).toBe('');
+      expect(newCalculation).toBe('');
     });
     test('It should add the given operator if the first character is not a minus operator', () => {
-      const newCalculationString = addOperator('/', '2');
+      const newCalculation = addOperator('/', '2');
 
-      expect(newCalculationString).toBe('2/');
+      expect(newCalculation).toBe('2/');
     });
   });
 
   describe('Multiple character calculation string', () => {
     test('It should add a minus operator if the last character is an operator other than minus operator', () => {
-      const newCalculationString = addOperator('-', '245/23+');
+      const newCalculation = addOperator('-', '245/23+');
 
-      expect(newCalculationString).toBe('245/23+-');
+      expect(newCalculation).toBe('245/23+-');
     });
     test('It should remove the minus operator if the given operator is a minus operator and the calculation string ends with a minus operator', () => {
-      const newCalculationString = addOperator('-', '24*-');
+      const newCalculation = addOperator('-', '24*-');
 
-      expect(newCalculationString).toBe('24*');
+      expect(newCalculation).toBe('24*');
     });
     test('It should remove the both operators and add the given operator if the given operator is other than minus operator and the calculation string ends with an operator and a minus operator', () => {
-      const newCalculationString = addOperator('*', '223/-');
+      const newCalculation = addOperator('*', '223/-');
 
-      expect(newCalculationString).toBe('223*');
+      expect(newCalculation).toBe('223*');
     });
     test('It should return the same calculation string if the last character is the same operator as the given operator', () => {
-      const calculationString1 = '1+';
-      const calculationString2 = '1*';
+      const calculation1 = '1+';
+      const calculation2 = '1*';
 
-      const newCalculationString1 = addOperator('+', calculationString1);
-      const newCalculationString2 = addOperator('*', calculationString2);
+      const newCalculation1 = addOperator('+', calculation1);
+      const newCalculation2 = addOperator('*', calculation2);
 
-      expect(newCalculationString1).toBe(calculationString1);
-      expect(newCalculationString2).toBe(calculationString2);
+      expect(newCalculation1).toBe(calculation1);
+      expect(newCalculation2).toBe(calculation2);
     });
     test('It should replace the operator with the given operator if the last character is operator', () => {
-      const newCalculationString = addOperator('*', '92/');
+      const newCalculation = addOperator('*', '92/');
 
-      expect(newCalculationString).toBe('92*');
+      expect(newCalculation).toBe('92*');
     });
     test('It should add the given operator if the last character is a number', () => {
-      const newCalculationString = addOperator('/', '239+543');
+      const newCalculation = addOperator('/', '239+543');
 
-      expect(newCalculationString).toBe('239+543/');
+      expect(newCalculation).toBe('239+543/');
     });
   });
 });

--- a/src/functions/addOperator/utils.ts
+++ b/src/functions/addOperator/utils.ts
@@ -1,12 +1,12 @@
 import { Calculation } from '@src/types';
 import { isEndsWith, removeCharactersFromEnd } from '@src/utils';
 
-const toggleMinusOperator = (calculationString: Calculation): Calculation => {
-  if (isEndsWith(calculationString, '-')) {
-    return removeCharactersFromEnd(calculationString);
+const toggleMinusOperator = (calculation: Calculation): Calculation => {
+  if (isEndsWith(calculation, '-')) {
+    return removeCharactersFromEnd(calculation);
   }
 
-  return `${calculationString}-`;
+  return `${calculation}-`;
 };
 
 export { toggleMinusOperator };

--- a/src/functions/addOperator/utils.ts
+++ b/src/functions/addOperator/utils.ts
@@ -1,9 +1,7 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { isEndsWith, removeCharactersFromEnd } from '@src/utils';
 
-const toggleMinusOperator = (
-  calculationString: CalculationString,
-): CalculationString => {
+const toggleMinusOperator = (calculationString: Calculation): Calculation => {
   if (isEndsWith(calculationString, '-')) {
     return removeCharactersFromEnd(calculationString);
   }

--- a/src/functions/addThousandsSeparator/index.ts
+++ b/src/functions/addThousandsSeparator/index.ts
@@ -1,9 +1,7 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { addSeparator, isEndsWithWholeNumber, wholeNumberRegex } from './utils';
 
-const addThousandsSeparator = (
-  calculationString: CalculationString,
-): CalculationString => {
+const addThousandsSeparator = (calculationString: Calculation): Calculation => {
   if (!isEndsWithWholeNumber(calculationString)) {
     return calculationString;
   }

--- a/src/functions/addThousandsSeparator/index.ts
+++ b/src/functions/addThousandsSeparator/index.ts
@@ -1,12 +1,12 @@
 import { Calculation } from '@src/types';
 import { addSeparator, isEndsWithWholeNumber, wholeNumberRegex } from './utils';
 
-const addThousandsSeparator = (calculationString: Calculation): Calculation => {
-  if (!isEndsWithWholeNumber(calculationString)) {
-    return calculationString;
+const addThousandsSeparator = (calculation: Calculation): Calculation => {
+  if (!isEndsWithWholeNumber(calculation)) {
+    return calculation;
   }
 
-  return calculationString.replace(
+  return calculation.replace(
     wholeNumberRegex,
     (match, firstPart, wholeNumber) => {
       if (wholeNumber.length < 4) return match;

--- a/src/functions/addThousandsSeparator/test.ts
+++ b/src/functions/addThousandsSeparator/test.ts
@@ -2,70 +2,54 @@ import { addThousandsSeparator } from '.';
 
 describe('addThousandsSeparator (Function)', () => {
   test('It should return the calculation string as is if the last character is an math operator', () => {
-    const calculationString = '23/2*';
-    const newCalculationString = addThousandsSeparator(calculationString);
+    const calculation = '23/2*';
+    const newCalculation = addThousandsSeparator(calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should return the calculation string as is if the last part of the calculation string is a decimal number', () => {
-    const calculationString = '8+3.3';
-    const newCalculationString = addThousandsSeparator(calculationString);
+    const calculation = '8+3.3';
+    const newCalculation = addThousandsSeparator(calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should return the calculation string as is if the last part of the calculation string is less than a thousand', () => {
-    const calculationString = '23+234';
-    const newCalculationString = addThousandsSeparator(calculationString);
+    const calculation = '23+234';
+    const newCalculation = addThousandsSeparator(calculation);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
   test('It should add thousands separators if the last part of the calculation string is a whole number', () => {
     const calculations: {
-      calculationString: string;
-      calculationStringWithSeparator: string;
+      calculation: string;
+      calculationWithSeparator: string;
     }[] = [
       {
-        calculationString: '79+27/99*233427976',
-        calculationStringWithSeparator: '79+27/99*233,427,976',
+        calculation: '79+27/99*233427976',
+        calculationWithSeparator: '79+27/99*233,427,976',
       },
       {
-        calculationString: '1962',
-        calculationStringWithSeparator: '1,962',
+        calculation: '1962',
+        calculationWithSeparator: '1,962',
       },
       {
-        calculationString: '2723792',
-        calculationStringWithSeparator: '2,723,792',
+        calculation: '2723792',
+        calculationWithSeparator: '2,723,792',
       },
       {
-        calculationString: '22481',
-        calculationStringWithSeparator: '22,481',
+        calculation: '22481',
+        calculationWithSeparator: '22,481',
       },
     ];
 
-    const newCalculationString0 = addThousandsSeparator(
-      calculations[0].calculationString,
-    );
-    const newCalculationString1 = addThousandsSeparator(
-      calculations[1].calculationString,
-    );
-    const newCalculationString2 = addThousandsSeparator(
-      calculations[2].calculationString,
-    );
-    const newCalculationString3 = addThousandsSeparator(
-      calculations[3].calculationString,
-    );
+    const newCalculation0 = addThousandsSeparator(calculations[0].calculation);
+    const newCalculation1 = addThousandsSeparator(calculations[1].calculation);
+    const newCalculation2 = addThousandsSeparator(calculations[2].calculation);
+    const newCalculation3 = addThousandsSeparator(calculations[3].calculation);
 
-    expect(newCalculationString0).toBe(
-      calculations[0].calculationStringWithSeparator,
-    );
-    expect(newCalculationString1).toBe(
-      calculations[1].calculationStringWithSeparator,
-    );
-    expect(newCalculationString2).toBe(
-      calculations[2].calculationStringWithSeparator,
-    );
-    expect(newCalculationString3).toBe(
-      calculations[3].calculationStringWithSeparator,
-    );
+    expect(newCalculation0).toBe(calculations[0].calculationWithSeparator);
+    expect(newCalculation1).toBe(calculations[1].calculationWithSeparator);
+    expect(newCalculation2).toBe(calculations[2].calculationWithSeparator);
+    expect(newCalculation3).toBe(calculations[3].calculationWithSeparator);
   });
 });

--- a/src/functions/addThousandsSeparator/utils.ts
+++ b/src/functions/addThousandsSeparator/utils.ts
@@ -1,8 +1,8 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
 const wholeNumberRegex = /^(.*\D{1})?(?<!\d+\.\d*)(\d+)$/;
 
-const isEndsWithWholeNumber = (calculationString: CalculationString): boolean =>
+const isEndsWithWholeNumber = (calculationString: Calculation): boolean =>
   wholeNumberRegex.test(calculationString);
 
 const addSeparator = (wholeNumber: string): string => {

--- a/src/functions/addThousandsSeparator/utils.ts
+++ b/src/functions/addThousandsSeparator/utils.ts
@@ -2,8 +2,8 @@ import { Calculation } from '@src/types';
 
 const wholeNumberRegex = /^(.*\D{1})?(?<!\d+\.\d*)(\d+)$/;
 
-const isEndsWithWholeNumber = (calculationString: Calculation): boolean =>
-  wholeNumberRegex.test(calculationString);
+const isEndsWithWholeNumber = (calculation: Calculation): boolean =>
+  wholeNumberRegex.test(calculation);
 
 const addSeparator = (wholeNumber: string): string => {
   const wholeNumberArray = wholeNumber.split('');

--- a/src/functions/clearAll/index.ts
+++ b/src/functions/clearAll/index.ts
@@ -1,5 +1,5 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
-const clearAll = (): CalculationString => '';
+const clearAll = (): Calculation => '';
 
 export { clearAll };

--- a/src/functions/clearAll/test.ts
+++ b/src/functions/clearAll/test.ts
@@ -2,8 +2,8 @@ import { clearAll } from '.';
 
 describe('clearAll (Function)', () => {
   test('It should return an empty string', () => {
-    const newCalculationString = clearAll();
+    const newCalculation = clearAll();
 
-    expect(newCalculationString).toBe('');
+    expect(newCalculation).toBe('');
   });
 });

--- a/src/functions/clearOne/index.ts
+++ b/src/functions/clearOne/index.ts
@@ -1,7 +1,7 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { removeCharactersFromEnd } from '@src/utils';
 
-const clearOne = (calculationString: CalculationString) =>
+const clearOne = (calculationString: Calculation) =>
   removeCharactersFromEnd(calculationString);
 
 export { clearOne };

--- a/src/functions/clearOne/index.ts
+++ b/src/functions/clearOne/index.ts
@@ -1,7 +1,7 @@
 import { Calculation } from '@src/types';
 import { removeCharactersFromEnd } from '@src/utils';
 
-const clearOne = (calculationString: Calculation) =>
-  removeCharactersFromEnd(calculationString);
+const clearOne = (calculation: Calculation) =>
+  removeCharactersFromEnd(calculation);
 
 export { clearOne };

--- a/src/functions/clearOne/test.ts
+++ b/src/functions/clearOne/test.ts
@@ -2,16 +2,14 @@ import { clearOne } from '.';
 
 describe('clearOne (Function)', () => {
   test('It should remove the last character of the calculation string', () => {
-    const calculationString = '24+2';
-    const newCalculationString = clearOne(calculationString);
+    const calculation = '24+2';
+    const newCalculation = clearOne(calculation);
 
-    expect(newCalculationString).toBe(
-      calculationString.slice(0, calculationString.length - 1),
-    );
+    expect(newCalculation).toBe(calculation.slice(0, calculation.length - 1));
   });
   test('It returns empty string if the calculation string is empty', () => {
-    const newCalculationString = clearOne('');
+    const newCalculation = clearOne('');
 
-    expect(newCalculationString).toBe('');
+    expect(newCalculation).toBe('');
   });
 });

--- a/src/functions/convertOperators/index.ts
+++ b/src/functions/convertOperators/index.ts
@@ -1,4 +1,4 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { getKeyByValue } from '@src/utils';
 
 const operatorMap: Record<string, string> = {
@@ -12,9 +12,9 @@ type Options = {
 };
 
 const convertOperators = (
-  calculationString: CalculationString,
+  calculationString: Calculation,
   options: Options = { toSpecial: true },
-): CalculationString => {
+): Calculation => {
   const { toSpecial } = options;
 
   const operatorRegex = new RegExp(

--- a/src/functions/convertOperators/index.ts
+++ b/src/functions/convertOperators/index.ts
@@ -12,7 +12,7 @@ type Options = {
 };
 
 const convertOperators = (
-  calculationString: Calculation,
+  calculation: Calculation,
   options: Options = { toSpecial: true },
 ): Calculation => {
   const { toSpecial } = options;
@@ -25,7 +25,7 @@ const convertOperators = (
     'g',
   );
 
-  return calculationString.replaceAll(operatorRegex, (match) =>
+  return calculation.replaceAll(operatorRegex, (match) =>
     toSpecial
       ? operatorMap[match]
       : (getKeyByValue(operatorMap, match) as string),

--- a/src/functions/convertOperators/test.ts
+++ b/src/functions/convertOperators/test.ts
@@ -3,16 +3,16 @@ import { convertOperators } from '.';
 describe('convertOperators (Function)', () => {
   test('It should replace the regular operators with special operators', () => {
     const calculationPair = ['43/7-65*27', '43÷7–65×27'];
-    const newCalculationString = convertOperators(calculationPair[0]);
+    const newCalculation = convertOperators(calculationPair[0]);
 
-    expect(newCalculationString).toBe(calculationPair[1]);
+    expect(newCalculation).toBe(calculationPair[1]);
   });
   test('It should replace the special operators with regular operators', () => {
     const calculationPair = ['27–237×87÷2', '27-237*87/2'];
-    const newCalculationString = convertOperators(calculationPair[0], {
+    const newCalculation = convertOperators(calculationPair[0], {
       toSpecial: false,
     });
 
-    expect(newCalculationString).toBe(calculationPair[1]);
+    expect(newCalculation).toBe(calculationPair[1]);
   });
 });

--- a/src/functions/getResult/index.ts
+++ b/src/functions/getResult/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-eval */
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 import { isEndsWithOperator, removeCharactersFromEnd } from '@src/utils';
 import { validateCalculationString } from './utils';
 
-const getResult = (calculationString: CalculationString): string => {
+const getResult = (calculationString: Calculation): string => {
   try {
     if (!validateCalculationString(calculationString)) {
       throw new Error();

--- a/src/functions/getResult/index.ts
+++ b/src/functions/getResult/index.ts
@@ -3,16 +3,16 @@ import { Calculation } from '@src/types';
 import { isEndsWithOperator, removeCharactersFromEnd } from '@src/utils';
 import { validateCalculationString } from './utils';
 
-const getResult = (calculationString: Calculation): string => {
+const getResult = (calculation: Calculation): string => {
   try {
-    if (!validateCalculationString(calculationString)) {
+    if (!validateCalculationString(calculation)) {
       throw new Error();
     }
 
     return `${eval?.(
-      isEndsWithOperator(calculationString)
-        ? removeCharactersFromEnd(calculationString)
-        : calculationString,
+      isEndsWithOperator(calculation)
+        ? removeCharactersFromEnd(calculation)
+        : calculation,
     )}`;
   } catch {
     throw new Error('Calculation string is in an unsupported format');

--- a/src/functions/getResult/index.ts
+++ b/src/functions/getResult/index.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-eval */
 import { Calculation } from '@src/types';
 import { isEndsWithOperator, removeCharactersFromEnd } from '@src/utils';
-import { validateCalculationString } from './utils';
+import { validateCalculation } from './utils';
 
 const getResult = (calculation: Calculation): string => {
   try {
-    if (!validateCalculationString(calculation)) {
+    if (!validateCalculation(calculation)) {
       throw new Error();
     }
 

--- a/src/functions/getResult/utils.ts
+++ b/src/functions/getResult/utils.ts
@@ -1,8 +1,6 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
-const validateCalculationString = (
-  calculationString: CalculationString,
-): boolean => {
+const validateCalculationString = (calculationString: Calculation): boolean => {
   const validationRegex = /^[0-9.+\-*/]+$/;
 
   return validationRegex.test(calculationString);

--- a/src/functions/getResult/utils.ts
+++ b/src/functions/getResult/utils.ts
@@ -1,9 +1,9 @@
 import { Calculation } from '@src/types';
 
-const validateCalculationString = (calculationString: Calculation): boolean => {
+const validateCalculationString = (calculation: Calculation): boolean => {
   const validationRegex = /^[0-9.+\-*/]+$/;
 
-  return validationRegex.test(calculationString);
+  return validationRegex.test(calculation);
 };
 
 export { validateCalculationString };

--- a/src/functions/getResult/utils.ts
+++ b/src/functions/getResult/utils.ts
@@ -1,9 +1,9 @@
 import { Calculation } from '@src/types';
 
-const validateCalculationString = (calculation: Calculation): boolean => {
+const validateCalculation = (calculation: Calculation): boolean => {
   const validationRegex = /^[0-9.+\-*/]+$/;
 
   return validationRegex.test(calculation);
 };
 
-export { validateCalculationString };
+export { validateCalculation };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,3 @@
-type CalculationString = string;
+type Calculation = string;
 
-export { CalculationString };
+export { Calculation };

--- a/src/utils/isEndsWith/index.ts
+++ b/src/utils/isEndsWith/index.ts
@@ -1,11 +1,11 @@
 import { Calculation } from '@src/types';
 
-const isEndsWith = (calculationString: Calculation, check: string) => {
+const isEndsWith = (calculation: Calculation, check: string) => {
   if (check.length !== 1) {
     throw new Error('The length of check string must be one');
   }
 
-  return calculationString.at(-1) === check;
+  return calculation.at(-1) === check;
 };
 
 export { isEndsWith };

--- a/src/utils/isEndsWith/index.ts
+++ b/src/utils/isEndsWith/index.ts
@@ -1,6 +1,6 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
-const isEndsWith = (calculationString: CalculationString, check: string) => {
+const isEndsWith = (calculationString: Calculation, check: string) => {
   if (check.length !== 1) {
     throw new Error('The length of check string must be one');
   }

--- a/src/utils/isEndsWithOperator/index.ts
+++ b/src/utils/isEndsWithOperator/index.ts
@@ -1,9 +1,9 @@
 import { Calculation } from '@src/types';
 
-const isEndsWithOperator = (calculationString: Calculation) => {
+const isEndsWithOperator = (calculation: Calculation) => {
   const operators = ['+', '-', '*', '/'];
 
-  const lastCharacter = calculationString.at(-1);
+  const lastCharacter = calculation.at(-1);
 
   return lastCharacter ? operators.includes(lastCharacter) : false;
 };

--- a/src/utils/isEndsWithOperator/index.ts
+++ b/src/utils/isEndsWithOperator/index.ts
@@ -1,7 +1,8 @@
-import { operators } from '@src/constants';
 import { CalculationString } from '@src/types';
 
 const isEndsWithOperator = (calculationString: CalculationString) => {
+  const operators = ['+', '-', '*', '/'];
+
   const lastCharacter = calculationString.at(-1);
 
   return lastCharacter ? operators.includes(lastCharacter) : false;

--- a/src/utils/isEndsWithOperator/index.ts
+++ b/src/utils/isEndsWithOperator/index.ts
@@ -1,6 +1,6 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
-const isEndsWithOperator = (calculationString: CalculationString) => {
+const isEndsWithOperator = (calculationString: Calculation) => {
   const operators = ['+', '-', '*', '/'];
 
   const lastCharacter = calculationString.at(-1);

--- a/src/utils/removeCharactersFromEnd/index.ts
+++ b/src/utils/removeCharactersFromEnd/index.ts
@@ -1,9 +1,9 @@
-import { CalculationString } from '@src/types';
+import { Calculation } from '@src/types';
 
 const removeCharactersFromEnd = (
-  calculationString: CalculationString,
-  count: number = 1
-): CalculationString => {
+  calculationString: Calculation,
+  count: number = 1,
+): Calculation => {
   if (count > calculationString.length) {
     return '';
   }

--- a/src/utils/removeCharactersFromEnd/index.ts
+++ b/src/utils/removeCharactersFromEnd/index.ts
@@ -1,14 +1,14 @@
 import { Calculation } from '@src/types';
 
 const removeCharactersFromEnd = (
-  calculationString: Calculation,
+  calculation: Calculation,
   count: number = 1,
 ): Calculation => {
-  if (count > calculationString.length) {
+  if (count > calculation.length) {
     return '';
   }
 
-  return calculationString.slice(0, calculationString.length - count);
+  return calculation.slice(0, calculation.length - count);
 };
 
 export { removeCharactersFromEnd };

--- a/src/utils/removeCharactersFromEnd/test.ts
+++ b/src/utils/removeCharactersFromEnd/test.ts
@@ -2,25 +2,25 @@ import { removeCharactersFromEnd } from '.';
 
 describe('removeCharactersFromEnd (Utility Function)', () => {
   test('It should remove only the last character by default if the count parameter is not specified', () => {
-    const newCalculationString = removeCharactersFromEnd('2+51');
+    const newCalculation = removeCharactersFromEnd('2+51');
 
-    expect(newCalculationString).toBe('2+5');
+    expect(newCalculation).toBe('2+5');
   });
   test('It should remove given number of characters from at the end of the calculation string', () => {
-    const newCalculationString = removeCharactersFromEnd('234+221/3.7', 3);
+    const newCalculation = removeCharactersFromEnd('234+221/3.7', 3);
 
-    expect(newCalculationString).toBe('234+221/');
+    expect(newCalculation).toBe('234+221/');
   });
   test('It should remove the whole string if the given number is bigger than the length of calculation string', () => {
-    const newCalculationString = removeCharactersFromEnd('273*33+1', 10);
+    const newCalculation = removeCharactersFromEnd('273*33+1', 10);
 
-    expect(newCalculationString).toBe('');
+    expect(newCalculation).toBe('');
   });
   test('It should remove nothing if the given number is zero', () => {
-    const calculationString = '234/3';
+    const calculation = '234/3';
 
-    const newCalculationString = removeCharactersFromEnd(calculationString, 0);
+    const newCalculation = removeCharactersFromEnd(calculation, 0);
 
-    expect(newCalculationString).toBe(calculationString);
+    expect(newCalculation).toBe(calculation);
   });
 });


### PR DESCRIPTION
### Changes
- The `operators` constant moved to inside of the `isEndsWithOperator` function. (Because it is not used elsewhere.)
- The type `CalculationString` is renamed to `Calculation`.
- The parameter name `calculationString` is renamed to `calculation` everywhere.
- The first parameter `operator` of the `addOperator` function is renamed to `operatorToAdd`.